### PR TITLE
Fix timed property saves

### DIFF
--- a/src/rootPages/Designer/ui_work_interface_workspace_details_properties.js
+++ b/src/rootPages/Designer/ui_work_interface_workspace_details_properties.js
@@ -40,7 +40,7 @@ export default function (AB) {
          this._handler_onChange = (waitDuration = 3000, skipEmit = false) => {
             if (!this.CurrentView) return;
 
-            this.busy();
+            // this.busy();
 
             let values = this.currentPanel.values();
 
@@ -67,6 +67,7 @@ export default function (AB) {
                clearTimeout(view.__timedSave);
             }
             view.__timedSave = setTimeout(async () => {
+               this.busy();
                try {
                   await view.save();
                   delete view.__timedSave;


### PR DESCRIPTION
We have code written to only save after the properties haven't changed for 3 seconds. However, I think we set busy to early. Now we wait 3 seconds before saving and no edits are possible.

I moved `this.busy()` to just before we save.