### PR TITLE
Various UI improvements when working with the Link Page Help widget in the Designer.

### DIFF
--- a/src/rootPages/Designer/properties/views/ABViewCarousel.js
+++ b/src/rootPages/Designer/properties/views/ABViewCarousel.js
@@ -50,6 +50,9 @@ export default function (AB) {
          // if the user clicks [cancel] or [close];
 
          this.linkPageComponent = new LinkPageHelper();
+         this.linkPageComponent.on("changed", () => {
+            this.onChange();
+         });
       }
 
       static get key() {

--- a/src/rootPages/Designer/properties/views/ABViewDataview.js
+++ b/src/rootPages/Designer/properties/views/ABViewDataview.js
@@ -60,7 +60,7 @@ export default function (AB) {
          super.init(this.AB);
 
          this.linkPageComponent.init();
-         this.linkPageComponent.on("change", () => {
+         this.linkPageComponent.on("changed", () => {
             this.onChange();
          });
       }

--- a/src/rootPages/Designer/properties/views/ABViewGrid.js
+++ b/src/rootPages/Designer/properties/views/ABViewGrid.js
@@ -190,6 +190,13 @@ export default function (AB) {
                            onChange: (newv, oldv) => {
                               if (newv != oldv) {
                                  this.linkPageComponent.clear();
+                                 // the linkPageComponent needs to refresh
+                                 // itself with the possible Link Pages
+                                 // that are related to this new DC:
+                                 this.linkPageComponent.viewLoad(
+                                    this.CurrentView,
+                                    newv
+                                 );
 
                                  let currDC =
                                     this.CurrentView?.AB.datacollectionByID(
@@ -590,8 +597,10 @@ export default function (AB) {
          if (!view) return;
 
          // this.viewEditing = view;
-
-         $$(ids.datacollection).setValue(view.settings.dataviewID);
+         let $dataCollection = $$(ids.datacollection);
+         $dataCollection.blockEvent();
+         $dataCollection.setValue(view.settings.dataviewID);
+         $dataCollection.unblockEvent();
          $$(ids.isEditable).setValue(view.settings.isEditable);
          $$(ids.massUpdate).setValue(view.settings.massUpdate);
          $$(ids.allowDelete).setValue(view.settings.allowDelete);

--- a/src/rootPages/Designer/properties/views/ABViewGrid.js
+++ b/src/rootPages/Designer/properties/views/ABViewGrid.js
@@ -56,6 +56,9 @@ export default function (AB) {
          // if the user clicks [cancel] or [close];
 
          this.linkPageComponent = new LinkPageHelper();
+         this.linkPageComponent.on("changed", () => {
+            this.onChange();
+         });
 
          this.PopupCountColumnsComponent = FPopupCountFields(
             AB,

--- a/src/rootPages/Designer/properties/views/ABViewKanban.js
+++ b/src/rootPages/Designer/properties/views/ABViewKanban.js
@@ -99,7 +99,7 @@ export default function (AB) {
          });
 
          this.linkPageComponent.init();
-         this.linkPageComponent.on("change", () => {
+         this.linkPageComponent.on("changed", () => {
             this.onChange();
          });
 

--- a/src/rootPages/Designer/properties/views/viewProperties/ABViewPropertyLinkPage.js
+++ b/src/rootPages/Designer/properties/views/viewProperties/ABViewPropertyLinkPage.js
@@ -198,6 +198,7 @@ export default function (AB, idBase) {
             } else {
                $$(this.ids.detailsPage).setValue(null);
             }
+            $$(this.ids.detailsPage).refresh();
 
             if (settings.editPage) {
                var edit = settings.editPage;
@@ -208,6 +209,7 @@ export default function (AB, idBase) {
             } else {
                $$(this.ids.editPage).setValue(null);
             }
+            $$(this.ids.editPage).refresh();
          }
 
          getSettings() {

--- a/src/rootPages/Designer/properties/views/viewProperties/ABViewPropertyLinkPage.js
+++ b/src/rootPages/Designer/properties/views/viewProperties/ABViewPropertyLinkPage.js
@@ -93,17 +93,29 @@ export default function (AB, idBase) {
             $$(this.ids.editPage).setValue("");
          }
 
-         viewLoad(view) {
+         /**
+          * @method viewLoad()
+          * Populate the LinkPage drop lists with appropriate values
+          * given the passed in {ABView}.  In cases where the dataviewID
+          * is being updated but isn't reflected in the {ABView} you can
+          * pass in the new dataviewID to match against.
+          * @param {ABView} view
+          *        The current Widget/View we are displaying for
+          * @param {uuid} dViewID
+          *        Any dataviewID override, or {false} otherwise.
+          */
+         viewLoad(view, dViewID = false) {
             this.view = view;
             const ids = this.ids;
+            dViewID = dViewID || view.settings.dataviewID;
 
             let filter = (v, widgetKey) => {
                return (
                   v.key == widgetKey &&
-                  (v.settings.dataviewID == view.settings.dataviewID ||
+                  (v.settings.dataviewID == dViewID ||
                      (this.AB ?? view.AB)?.datacollectionByID(
                         v.settings.dataviewID
-                     )?.datacollectionFollow?.id == view.settings.dataviewID)
+                     )?.datacollectionFollow?.id == dViewID)
                );
             };
 

--- a/src/rootPages/Designer/properties/views/viewProperties/ABViewPropertyLinkPage.js
+++ b/src/rootPages/Designer/properties/views/viewProperties/ABViewPropertyLinkPage.js
@@ -62,7 +62,7 @@ export default function (AB, idBase) {
                         labelWidth: uiConfig.labelWidthLarge,
                         options: [],
                         on: {
-                           onChange: () => this.emit("change"),
+                           onChange: () => this.emit("changed"),
                         },
                      },
                      {
@@ -75,7 +75,7 @@ export default function (AB, idBase) {
                         labelWidth: uiConfig.labelWidthLarge,
                         options: [],
                         on: {
-                           onChange: () => this.emit("change"),
+                           onChange: () => this.emit("changed"),
                         },
                      },
                   ],


### PR DESCRIPTION
I noticed several problems in the ABDesigner related to the display of the Link Page Helper (LPH) widget.
1. The LPH wants to show a filtered list of data collections based upon what the current widget it is associated with.  However, if on the properties page, you changed the data collection, the list in the dropdown didn't update.2. 
2. The Grid Properties wasn't paying attention to when the LPH had changed values so it wasn't initiating a save when the value was changed.3. 
3. The LPH was issuing "change" instead of "changed" like all the other page helpers.4. 

## Release Notes
<!-- #release_notes -->
- [fix] make sure the LinkPageHelper's droplists are updated on a ABViewGrid when a new datacollection is selected.
- [fix] make sure property dropdown lists visually reflect the newly updated values.
- [fix] have ABViewPropertyLinkPage helper emit "changed" like all the other helpers.
<!-- /release_notes --> 
