### PR TITLE
disable file upload button until at least one datasource is chosen

### DIFF
--- a/src/rootPages/Designer/properties/views/ABViewDocxBuilder.js
+++ b/src/rootPages/Designer/properties/views/ABViewDocxBuilder.js
@@ -72,6 +72,12 @@ export default function (AB) {
                         labelWidth: uiConfig.labelWidthLarge,
                         on: {
                            onChange: () => {
+                              if ($$(this.ids.datacollection).getValue()) {
+                                 $$(this.ids.docxFile).enable();
+                              } else {
+                                 $$(this.ids.docxFile).disable();
+                              }
+
                               this.onChange();
                            },
                         },
@@ -114,6 +120,15 @@ export default function (AB) {
                                  },
 
                                  onFileUploadError: (file, response) => {},
+                                 onViewShow: () => {
+                                    if (
+                                       $$(this.ids.datacollection).getValue()
+                                    ) {
+                                       $$(this.ids.docxFile).enable();
+                                    } else {
+                                       $$(this.ids.docxFile).disable();
+                                    }
+                                 },
                               },
                            },
                         ],


### PR DESCRIPTION
Our upload api requires an object ID for upload so we cannot upload without a source.


## Release Notes
<!-- #release_notes -->
- Prevent users from attempting a template upload that will fail.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
