### PR TITLE
Fix: ensure tiny-mce loads when used within another widget

### DIFF
--- a/src/rootPages/Designer/editors/views/ABViewDataview.js
+++ b/src/rootPages/Designer/editors/views/ABViewDataview.js
@@ -45,6 +45,7 @@ export default function (AB) {
          }
 
          onShow() {
+            super.onShow();
             this.component?.onShow?.();
          }
       };

--- a/src/rootPages/Designer/editors/views/ABViewDetail.js
+++ b/src/rootPages/Designer/editors/views/ABViewDetail.js
@@ -45,6 +45,7 @@ export default function (AB) {
          }
 
          onShow() {
+            super.onShow();
             this.component?.onShow?.();
          }
       };

--- a/src/rootPages/Designer/editors/views/ABViewLayout.js
+++ b/src/rootPages/Designer/editors/views/ABViewLayout.js
@@ -97,6 +97,12 @@ export default function (AB) {
             });
          }
 
+         onShow() {
+            if (this.CurrentView.views().some((v) => v.key === "text")) {
+               this.AB.custom["tinymce-editor"].init();
+            }
+         }
+
          detatch() {
             this.viewComponent?.detatch?.();
          }


### PR DESCRIPTION
https://github.com/digi-serve/ns_app/issues/441
https://github.com/digi-serve/ns_app/issues/462


## Release Notes
<!-- #release_notes -->
- fix an issue where text editor would not load with detail, dataview, and layout widgets
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
