### PR TITLE
Add hooks to load editor and view properties from plugins

### DIFF
--- a/src/rootPages/Designer/editors/EditorManager.js
+++ b/src/rootPages/Designer/editors/EditorManager.js
@@ -4,6 +4,8 @@
  * An Interface for managing all the various Component Editors we support.
  *
  */
+import _ABViewDefault from "./views/_ABViewDefault";
+
 export default function (AB) {
    const Editors = [];
    // {array}
@@ -42,6 +44,11 @@ export default function (AB) {
       const Klass = E.default(AB);
 
       Editors.push(Klass);
+   });
+
+   // Load editors from plugins
+   AB.plugins().forEach((p) => {
+      if (p.editor) Editors.push(p.editor(AB, _ABViewDefault));
    });
 
    return {

--- a/src/rootPages/Designer/properties/PropertyManager.js
+++ b/src/rootPages/Designer/properties/PropertyManager.js
@@ -4,6 +4,7 @@
  * An Interface for managing all the various Property Editors we support.
  *
  */
+import ABView from "./views/ABView";
 
 var PropertyMgr = null;
 
@@ -119,6 +120,10 @@ export default function (AB) {
          require("./views/ABViewText"),
       ].forEach((V) => {
          Views.push(V.default(AB));
+      });
+
+      AB.plugins().forEach((p) => {
+         if (p.viewProperty) Views.push(p.viewProperty(AB, ABView));
       });
 
       var MobileViews = [];


### PR DESCRIPTION
https://github.com/digi-serve/planning/issues/572

As we're moving closer to HR Teams release, I want to move away from needing to maintain different branches and building manually. I packaged the HR Teams Complex Widget as a plugin, in the style of ABDesigner. But this requires modification to ABDesigner, platform_web and core to load the relevant classes. 

See the plugin code here: https://github.com/digi-serve/plugin_HRTeams

The main goal is code separation. I still think we need to work on a more accessible plugin system, that simplifies adding custom features to the platform.

## Release Notes
<!-- #release_notes -->
- Add hooks to load editor and view properties from plugins
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
