### PR TITLE
Dynamically load process instances in process monitor

### DIFF
--- a/src/rootPages/Designer/ui_work_process_workspace_monitor.js
+++ b/src/rootPages/Designer/ui_work_process_workspace_monitor.js
@@ -297,6 +297,7 @@ export default function (AB) {
          };
          const self = this;
          const cb = function () {
+            // select the first record by default
             const id = this.getFirstId();
             this.select(id);
             self.showInstance(id);
@@ -333,7 +334,6 @@ export default function (AB) {
                   value: status,
                })
             );
-            where[statusField] = {};
          }
          const res = await this.model.findAll({
             where,
@@ -498,7 +498,6 @@ export default function (AB) {
       show() {
          $$(this.ids.component).show();
       }
-      busy() {}
    }
 
    return new UI_Work_Process_Workspace_Monitor();


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Dynamically load process instances in process monitor
<!-- /release_notes --> 

Previous we tried to load all data and sort/filter client side, which doesn't work well when we have many instances. Now uses sort by `update_at` on the server (See: https://github.com/digi-serve/appbuilder_platform_service/pull/161) so we can dynamically load on scroll.