### PR TITLE
Fix Random Designer Errors

### DIFF
--- a/src/rootPages/Designer/properties/PropertyManager.js
+++ b/src/rootPages/Designer/properties/PropertyManager.js
@@ -8,7 +8,7 @@ import ABView from "./views/ABView";
 
 var PropertyMgr = null;
 
-export default function(AB) {
+export default function (AB) {
    if (!PropertyMgr) {
       var Fields = [];
       // {array}
@@ -161,19 +161,19 @@ export default function(AB) {
           *        A filter for limiting which fields you want.
           * @return [{ClassUI(Field1)}, {ClassUI(Field2)}, ...]
           */
-         fields: function(f = () => true) {
+         fields: function (f = () => true) {
             return Fields.filter(f);
          },
 
-         processElements: function(f = () => true) {
+         processElements: function (f = () => true) {
             return Processes.filter(f);
          },
 
-         views: function(v = () => true) {
+         views: function (v = () => true) {
             return Views.filter(v);
          },
 
-         mobileViews: function(v = () => true) {
+         mobileViews: function (v = () => true) {
             return MobileViews.filter(v);
          },
       };

--- a/src/rootPages/Designer/properties/views/ABViewGrid.js
+++ b/src/rootPages/Designer/properties/views/ABViewGrid.js
@@ -758,11 +758,7 @@ export default function (AB) {
                showToolbar = true;
             }
          });
-         if (showToolbar) {
-            vals.settings.showToolbar = 1;
-         } else {
-            vals.settings.showToolbar = 0;
-         }
+         vals.settings.showToolbar = showToolbar ? 1 : 0;
 
          vals.settings.height = $$(ids.height).getValue();
          vals.settings.hideHeader = $$(ids.hideHeader).getValue();

--- a/src/rootPages/Designer/properties/views/ABViewGrid.js
+++ b/src/rootPages/Designer/properties/views/ABViewGrid.js
@@ -752,6 +752,18 @@ export default function (AB) {
          vals.settings.isSortable = $$(ids.isSortable).getValue();
          vals.settings.isExportable = $$(ids.isExportable).getValue();
 
+         let showToolbar = false;
+         ["massUpdate", "isSortable", "isExportable"].forEach((key) => {
+            if (vals.settings[key]) {
+               showToolbar = true;
+            }
+         });
+         if (showToolbar) {
+            vals.settings.showToolbar = 1;
+         } else {
+            vals.settings.showToolbar = 0;
+         }
+
          vals.settings.height = $$(ids.height).getValue();
          vals.settings.hideHeader = $$(ids.hideHeader).getValue();
          vals.settings.labelAsField = $$(ids.labelAsField).getValue();

--- a/src/rootPages/Designer/ui_work_process_workspace_monitor.js
+++ b/src/rootPages/Designer/ui_work_process_workspace_monitor.js
@@ -358,6 +358,13 @@ export default function (AB) {
             return;
          }
          const item = $$(ids.taskList).getItem(itemId);
+         if (!Array.isArray(item.log)) {
+            if (item.log === "") {
+               item.log = [];
+            } else {
+               item.log = (item.log || "").split(",");
+            }
+         }
          const logs = item.log.map((log, index) => {
             return { id: index, value: log };
          });


### PR DESCRIPTION
These were a few ui glitches I found when testing the CSVPack routines.

1) the ABViewGrid's are expecting a `this.setting.showToolbar` setting to be present to show the toolbar.  The kitchen sink app didn't have that value in the Grid definitions and were failing on my local.  So when trying to hunt things down, I didn't see us setting the value in the designer where we usually set these things.

2) In rare cases the processInstance.logs were coming in as strings instead of arrays. I make a special check to adjust in that case.

## Release Notes
<!-- #release_notes -->
- [fix] make sure processInstance.logs are in array format.
- [fix] the GridViewComponent is expecting a .showToolbar setting to be present
- [wip] eslint changes
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
