### PR TITLE
Fix ABDesigner's ability to display the layout widget

### DIFF
--- a/src/rootPages/Designer/ui_work_interface_workspace_editor_layout.js
+++ b/src/rootPages/Designer/ui_work_interface_workspace_editor_layout.js
@@ -261,7 +261,8 @@ export default function (AB) {
          editorUI.id = `${ids.editArea}_dashboard_layout`;
 
          // clear out widgets in our dashboard area
-         const idDashboard = editorUI.rows[0].id;
+         const subWidgets = editorUI.rows ?? editorUI.cols;
+         const idDashboard = subWidgets[0].id;
          const $dashboard = $$(idDashboard);
          if ($dashboard) $dashboard.clearAll();
 


### PR DESCRIPTION
[fix] workspace editor layout pane needs to handle layout widgets that support cols and not rows

James wrote me about this display error on the ABDesigner.