### PR TITLE
ABDesigner Layout error when widget has a .body property

### DIFF
--- a/src/rootPages/Designer/ui_work_interface_workspace_editor_layout.js
+++ b/src/rootPages/Designer/ui_work_interface_workspace_editor_layout.js
@@ -261,7 +261,17 @@ export default function (AB) {
          editorUI.id = `${ids.editArea}_dashboard_layout`;
 
          // clear out widgets in our dashboard area
-         const subWidgets = editorUI.rows ?? editorUI.cols;
+         var subWidgets = editorUI.rows ?? editorUI.cols;
+         if (!subWidgets || subWidgets.length === 0) {
+            if (editorUI.body) {
+               subWidgets = editorUI.body.rows ?? editorUI.body.cols;
+            }
+            if (!subWidgets || subWidgets.length === 0) {
+               console.error("Tell Johnny: No sub widgets found in editor UI");
+               console.error(editorUI);
+               return;
+            }
+         }
          const idDashboard = subWidgets[0].id;
          const $dashboard = $$(idDashboard);
          if ($dashboard) $dashboard.clearAll();


### PR DESCRIPTION
Added case where UI widget has a .body property that contains .row or .cols.

[fix] apparently we also have widgets that have a .body property